### PR TITLE
Make sure role-switch resets currently used BE module and pid

### DIFF
--- a/Classes/Backend/ToolbarItems/RoleSwitcher.php
+++ b/Classes/Backend/ToolbarItems/RoleSwitcher.php
@@ -28,10 +28,11 @@ namespace IchHabRecht\BegroupsRoles\Backend\ToolbarItems;
 use Doctrine\DBAL\Connection;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Toolbar\ToolbarItemInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Http\NullResponse;
+use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Localization\LanguageService;
@@ -69,6 +70,11 @@ class RoleSwitcher implements ToolbarItemInterface
     protected $pageRenderer;
 
     /**
+     * @var UriBuilder
+     */
+    protected $uriBuilder;
+
+    /**
      * @var array
      */
     protected $groups = [];
@@ -83,13 +89,15 @@ class RoleSwitcher implements ToolbarItemInterface
         Connection $connection = null,
         IconFactory $iconFactory = null,
         $languageService = null,
-        PageRenderer $pageRenderer = null
+        PageRenderer $pageRenderer = null,
+        UriBuilder $uriBuilder = null
     ) {
         $this->backendUser = $backendUser ?: $GLOBALS['BE_USER'];
         $this->connection = $connection ?: GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($this->backendUser->user_table);
         $this->iconFactory = $iconFactory ?: GeneralUtility::makeInstance(IconFactory::class);
         $this->languageService = $languageService ?: $GLOBALS['LANG'];
         $this->pageRenderer = $pageRenderer ?: GeneralUtility::makeInstance(PageRenderer::class);
+        $this->uriBuilder = $uriBuilder ?: GeneralUtility::makeInstance(UriBuilder::class);
     }
 
     /**
@@ -229,6 +237,8 @@ class RoleSwitcher implements ToolbarItemInterface
 
         $this->backendUser->setAndSaveSessionData('tx_begroupsroles_role', $newRole);
 
-        return new NullResponse();
+        return new JsonResponse([
+            'redirectUrl' => (string)$this->uriBuilder->buildUriFromRoute('main'),
+        ]);
     }
 }

--- a/Resources/Public/JavaScript/Toolbar/RoleSwitcher.js
+++ b/Resources/Public/JavaScript/Toolbar/RoleSwitcher.js
@@ -37,8 +37,9 @@ define(['jquery'], function($) {
 				data: {
 					role: $(this).data('role')
 				},
-				complete: function() {
-					document.location.reload();
+				dataType: 'json',
+				success: function(data) {
+					document.location.assign(data.redirectUrl);
 				}
 			});
 		})

--- a/Resources/Public/JavaScript/Toolbar/RoleSwitcher.js
+++ b/Resources/Public/JavaScript/Toolbar/RoleSwitcher.js
@@ -25,7 +25,7 @@
 /**
  * Module: TYPO3/CMS/BegroupsRoles/Toolbar/RoleSwitcher
  */
-define(['jquery'], function($) {
+define(['jquery', 'TYPO3/CMS/Backend/Storage/ModuleStateStorage'], function($) {
 	'use strict';
 
 	$(
@@ -39,6 +39,10 @@ define(['jquery'], function($) {
 				},
 				dataType: 'json',
 				success: function(data) {
+					// Reset currently selected pid in pagetree
+					ModuleStateStorage.update('web', 0, true, 0);
+
+					// Redirecting to main route
 					document.location.assign(data.redirectUrl);
 				}
 			});


### PR DESCRIPTION
This makes sure that the BE user will find a reset BE when changing roles:

* Unset the currently active pid in pagetree
* Refresh to `/typo3/main` (which will then redirect to the users default BE module)

Without that errors occure when the new role doesn't have access to the old roles module or selected pid.

Resolves: #25